### PR TITLE
Deid 1799

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,9 @@ pip install privateai_client
 from privateai_client import PAIClient
 from privateai_client import request_objects
 
-scheme = "http"
-host = "localhost"
-port = "8080"
+url="http://localhost:8080"
 
-client = PAIClient(scheme=scheme, host=host, port=port)
+client = PAIClient(url="http://localhost:8080")
 text_request = request_objects.process_text_obj(text=["My sample name is John Smith"])
 response = client.process_text(text_request)
 
@@ -67,10 +65,8 @@ Once created, the connection can be tested with the client's `ping` function
 
 ```python
 from privateai_client import PAIClient
-scheme = 'http'
-host = 'localhost'
-port = '8080'
-client = PAIClient(scheme, host, port)
+url = "http://localhost:8080"
+client = PAIClient(url=url)
 
 client.ping()
 ```
@@ -86,12 +82,21 @@ True
 ```python
 from privateai_client import PAIClient
 # On initialization
-client = PAIClient("http", "localhost", "8080", api_key='testkey')
+client = PAIClient(url="http://localhost:8080", api_key='testkey')
 
 # After initialization
-client = PAIClient("http", "localhost", "8080")
+client = PAIClient(url="http://localhost:8080")
+client.ping()
 client.add_api_key("testkey")
+client.ping()
 ```
+Output:
+
+```
+The request returned with a 401 Unauthorized
+True
+```
+
 
 #### Making Requests
 
@@ -246,7 +251,7 @@ import os
 import logging
 
 file_dir = "/path/to/file/directory"
-client = PAIClient("http", "localhost", "8080")
+client = PAIClient(url="http://localhost:8080")
 for file_name in os.listdir(file_dir):
     filepath = os.path.join(file_dir, file_name)
     if not os.path.isfile(filepath):
@@ -254,8 +259,6 @@ for file_name in os.listdir(file_dir):
     req_obj = request_objects.file_url_obj(uri=filepath)
     # NOTE this method of file processing requires the container to have an the input and output directories mounted
     resp = client.process_files_uri(req_obj)
-    if not resp.ok:
-        logging.error(f"response for file {file_name} returned with {resp.status_code}")
 ```
 
 #### Processing a Base64 file
@@ -271,7 +274,7 @@ file_dir = "/path/to/your/file"
 file_name = 'sample_file.pdf'
 filepath = os.path.join(file_dir,file_name)
 file_type= "type/of_file" #eg. application/pdf
-client = PAIClient("http", "localhost", "8080")
+client = PAIClient(url="http://localhost:8080")
 
 # Read from file
 with open(filepath, "rb") as b64_file:
@@ -282,8 +285,6 @@ with open(filepath, "rb") as b64_file:
 file_obj = request_objects.file_obj(data=file_data, content_type=file_type)
 request_obj = request_objects.file_base64_obj(file=file_obj)
 resp = client.process_files_base64(request_object=request_obj)
-if not resp.ok:
-    logging.error(f"response for file {file_name} returned with {resp.status_code}")
 
 # Write to file
 with open(os.path.join(file_dir,f"redacted-{file_name}"), 'wb') as redacted_file:
@@ -305,7 +306,7 @@ file_dir = "/path/to/your/file"
 file_name = 'sample_file.pdf'
 filepath = os.path.join(file_dir,file_name)
 file_type= "type/of_file" #eg. audio/mp3 or audio/wav
-client = PAIClient("http", "localhost", "8080")
+client = PAIClient(url="http://localhost:8080")
 
 
 file_dir = "/home/adam/workstation/file_processing/test_audio"
@@ -321,8 +322,6 @@ timestamp = request_objects.timestamp_obj(start=1.12, end=2.14)
 request_obj = request_objects.bleep_obj(file=file_obj, timestamps=[timestamp])
 
 resp = client.bleep(request_object=request_obj)
-if not resp.ok:
-    logging.error(f"response for file {file_name} returned with {resp.status_code}")
 with open(os.path.join(file_dir,f"redacted-{file_name}"), 'wb') as redacted_file:
     processed_file = resp.bleeped_file.encode("ascii")
     processed_file = base64.b64decode(processed_file, validate=True)
@@ -341,7 +340,7 @@ import pandas as pd
 from privateai_client import PAIClient
 from privateai_client.objects import request_objects
 
-client = PAIClient("http", "localhost", "8080")
+client = PAIClient(url="http://localhost:8080")
 data_frame = pd.DataFrame(
     {
         "Name": [
@@ -375,7 +374,7 @@ import pandas as pd
 from privateai_client import PAIClient
 from privateai_client.objects import request_objects
 
-client = PAIClient("http", "localhost", "8080")
+client = PAIClient(url="http://localhost:8080")
 data_frame = pd.DataFrame(
     {
         "Book": [
@@ -399,7 +398,7 @@ Reidentifying Text
 from privateai_client import PAIClient
 from privateai_client import request_objects
 
-client = PAIClient("http", "localhost", "8080")
+client = PAIClient(url="http://localhost:8080")
 
 # Deidentify the text
 initial_text = 'My name is John. I work for Private AI'

--- a/src/privateai_client/components/pai_responses.py
+++ b/src/privateai_client/components/pai_responses.py
@@ -1,4 +1,4 @@
-from requests import Response
+from requests import HTTPError, Response
 
 
 class BaseResponse:
@@ -6,6 +6,13 @@ class BaseResponse:
         self._response = response_object
         # Should be json or text
         self._json_response = json_response
+        if not self.response.ok:
+            message = (
+                f"The request returned with a {self.response.status_code} {self.reason}"
+            )
+            if self.response.status_code == 400:
+                message += f" -- {self.body.get('detail')}"
+            raise HTTPError(message)
 
     def __call__(self):
         return self.response
@@ -27,6 +34,10 @@ class BaseResponse:
         return self().status_code
 
     @property
+    def reason(self):
+        return self().reason
+
+    @property
     def body(self):
         if self._json_response:
             return self().json()
@@ -45,11 +56,7 @@ class BaseResponse:
             raise ValueError("get_attribute_entries needs a response of type json")
         body = self.body
         if type(body) is list:
-            return (
-                self.body[0].get(name)
-                if len(body) == 1
-                else [row.get(name) for row in self().json()]
-            )
+            return [row.get(name) for row in self().json()]
         elif type(body) is dict:
             return body.get(name)
 

--- a/src/privateai_client/components/pai_uris.py
+++ b/src/privateai_client/components/pai_uris.py
@@ -1,13 +1,26 @@
+import logging
+
+
 class PAIURIs:
-    def __init__(self, scheme, host, port=None):
-        self.valid_schemes = ["http", "https"]
-        scheme = scheme.split("://")[0]
-        if scheme not in self.valid_schemes:
-            raise ValueError(
-                f"Scheme must be one of the following: {', '.join(self.valid_schemes)}"
+    def __init__(self, url=None, scheme=None, host=None, port=None, **kwargs):
+        if url:
+            self._pai_uri = url
+        elif scheme and host:
+            logging.warning(
+                'Deprecation warning. scheme, host and port are no longer supported. Please use url when initializing the client. Eg. PAIClient(url="http://localhost:8080")'
             )
-        port = f":{port}" if port else ""
-        self._pai_uri = f"{scheme}://{host}{port}"
+            self.valid_schemes = ["http", "https"]
+            scheme = scheme.split("://")[0]
+            if scheme not in self.valid_schemes:
+                raise ValueError(
+                    f"Scheme must be one of the following: {', '.join(self.valid_schemes)}"
+                )
+            port = f":{port}" if port else ""
+            self._pai_uri = f"{scheme}://{host}{port}"
+        else:
+            raise ValueError(
+                "PAIClient needs either a url, or a scheme and host to initialize"
+            )
 
     @property
     def pai_uri(self):

--- a/src/privateai_client/components/pai_uris.py
+++ b/src/privateai_client/components/pai_uris.py
@@ -6,9 +6,6 @@ class PAIURIs:
         if url:
             self._pai_uri = url
         elif scheme and host:
-            logging.warning(
-                'Deprecation warning. scheme, host and port are no longer supported. Please use url when initializing the client. Eg. PAIClient(url="http://localhost:8080")'
-            )
             self.valid_schemes = ["http", "https"]
             scheme = scheme.split("://")[0]
             if scheme not in self.valid_schemes:

--- a/src/privateai_client/pai_client.py
+++ b/src/privateai_client/pai_client.py
@@ -1,6 +1,7 @@
 import logging
-from requests import HTTPError
 from typing import Union
+
+from requests import HTTPError
 
 from .components import *
 
@@ -10,7 +11,14 @@ class PAIClient:
     Client used to connect to private-ai's deidentication service
     """
 
-    def __init__(self, scheme=None, host=None, port=None, url=None, **kwargs):
+    def __init__(
+        self,
+        scheme: str = None,
+        host: str = None,
+        port: str = None,
+        url: str = None,
+        **kwargs,
+    ):
         # Add source url
         self.uris = PAIURIs(url, scheme, host, port)
         self.get = PAIGetRequests(self.uris)

--- a/src/privateai_client/pai_client.py
+++ b/src/privateai_client/pai_client.py
@@ -41,10 +41,10 @@ class PAIClient:
         for subclass in [self.get, self.post]:
             subclass.headers = {**auth_header, **subclass.base_header}
 
-    def add_api_key(self, api_key):
+    def add_api_key(self, api_key: str):
         self._add_auth("api_key", api_key)
 
-    def add_bearer_token(self, token):
+    def add_bearer_token(self, token: str):
         self._add_auth("bearer_token", token)
 
     def ping(self):

--- a/src/privateai_client/pai_client.py
+++ b/src/privateai_client/pai_client.py
@@ -9,9 +9,9 @@ class PAIClient:
     Client used to connect to private-ai's deidentication service
     """
 
-    def __init__(self, scheme: str, host: str, port: str = None, **kwargs):
+    def __init__(self, scheme=None, host=None, port=None, url=None, **kwargs):
         # Add source url
-        self.uris = PAIURIs(scheme, host, port)
+        self.uris = PAIURIs(url, scheme, host, port)
         self.get = PAIGetRequests(self.uris)
         self.post = PAIPostRequests(self.uris)
         if "api_key" in kwargs.keys():


### PR DESCRIPTION
### What's Changed?

Non-200 requests now raise an HTTP Error . Decided not to use requests' raise_for_status function so that we can include the details of the response if we get one from the DEID service.

Added a couple usability enhancement that I'd like to get out so that any blog posts that show client use can include them in the examples:
- The client accepts url as an argument. the original initialization arguments are accepted and unchanged but will  log a deprecation warning so they can be phased out in a future release.
- The response objects return aggregate list of the attributes selected if the response is a list

### PR Checklist

- [ ] Updated unit tests
- [x] Ran unit tests