### PR TITLE
DEID-1867 LLM Wrapper 

### DIFF
--- a/src/privateai_client/components/llm_connector.py
+++ b/src/privateai_client/components/llm_connector.py
@@ -5,11 +5,11 @@ class LLMConnector:
 
     accepted_llms = ["openai", "cohere", "palm", "vertexai"]
         
-    def _vertexai_prompt_completion(self, prompt:str, chat_model_name:str, project:str=None, location:str = None, chat_parameters: List = None, **kwargs):
+    def _vertexai_prompt_completion(self, prompt:str, init_parameters:Dict, chat_model_name:str, chat_parameters: Dict = None, **kwargs):
         import vertexai
         from vertexai.preview.language_models import ChatModel
 
-        vertexai.init(project=project, location=location)
+        vertexai.init(init_parameters)
         chat_model = ChatModel.from_pretrained(chat_model_name)
         chat = chat_model.start_chat(chat_parameters)
         completion = chat.send_message(f'{prompt}', **kwargs)

--- a/src/privateai_client/components/llm_connector.py
+++ b/src/privateai_client/components/llm_connector.py
@@ -5,15 +5,14 @@ class LLMConnector:
 
     accepted_llms = ["openai", "cohere", "palm", "vertexai"]
         
-    def _vertexai_prompt_completion(self, prompt:str, chat_model_name:str, project:str=None, location:str = None, **kwargs):
+    def _vertexai_prompt_completion(self, prompt:str, chat_model_name:str, project:str=None, location:str = None, chat_parameters: List = None, **kwargs):
         import vertexai
         from vertexai.preview.language_models import ChatModel
 
         vertexai.init(project=project, location=location)
         chat_model = ChatModel.from_pretrained(chat_model_name)
-        chat_parameters = kwargs
-        chat = chat_model.start_chat(**kwargs)
-        completion = chat.send_message(f'{prompt}', chat_parameters)
+        chat = chat_model.start_chat(chat_parameters)
+        completion = chat.send_message(f'{prompt}', **kwargs)
         return completion.text
     
     def _cohere_prompt_completion(self, prompt:str, **kwargs):

--- a/src/privateai_client/components/llm_connector.py
+++ b/src/privateai_client/components/llm_connector.py
@@ -1,0 +1,60 @@
+import os
+from typing import Dict, List, Union
+
+class LLMConnector:
+
+    accepted_llms = ["openai", "cohere", "palm", "vertexai"]
+        
+    def _vertexai_prompt_completion(self, prompt:str, chat_model_name:str, project:str=None, location:str = None, **kwargs):
+        import vertexai
+        from vertexai.preview.language_models import ChatModel
+
+        vertexai.init(project=project, location=location)
+        chat_model = ChatModel.from_pretrained(chat_model_name)
+        chat_parameters = kwargs
+        chat = chat_model.start_chat(**kwargs)
+        completion = chat.send_message(f'{prompt}', chat_parameters)
+        return completion.text
+    
+    def _cohere_prompt_completion(self, prompt:str, **kwargs):
+        import cohere
+        if kwargs.get("model_api_key"):
+            model_api_key = kwargs.pop("model_api_key")
+        elif os.getenv["model_api_key"]:
+            model_api_key = os.getenv["model_api_key"]
+        cohere_llm = cohere.Client(api_key=model_api_key, **kwargs)
+        response = cohere_llm.generate(
+            prompt=prompt,
+            **kwargs)
+        return [prompt, response.generations[0].text]
+
+    def _openai_prompt_completion(self, prompt:Union[str, List[Dict[str,str]]], **kwargs):
+        import openai
+        model_api_key = None
+        if kwargs.get("model_api_key"):
+            model_api_key = kwargs.pop("model_api_key")
+        if type(prompt) == str:
+            prompt = [
+                {"role": "user",
+                "content": prompt},
+            ]
+
+        openai.api_key = model_api_key
+        completion = openai.ChatCompletion.create(
+        messages=prompt,
+        **kwargs
+        )
+        prompt = [prompt[0]["content"], completion.choices[0].message["content"]]
+        return prompt
+
+    def send_redacted_prompt(self, prompt, llm_model: str, **kwargs):
+        if llm_model.lower() in self.accepted_llms:
+            if llm_model.lower() == "openai":
+                return self._openai_prompt_completion(prompt, **kwargs)
+            elif llm_model.lower() == "cohere":
+                return self._cohere_prompt_completion(prompt, **kwargs)
+            elif llm_model.lower() == "palm" or llm_model.lower() == "vertexai":
+                return self._vertexai_prompt_completion(prompt, **kwargs)
+        else:
+             raise ValueError(f"{llm_model} is not an accepted LLM. Accepted LLMs are {self.accepted_llms}")
+

--- a/src/privateai_client/components/llm_connector.py
+++ b/src/privateai_client/components/llm_connector.py
@@ -13,7 +13,7 @@ class LLMConnector:
         chat_model = ChatModel.from_pretrained(chat_model_name)
         chat = chat_model.start_chat(chat_parameters)
         completion = chat.send_message(f'{prompt}', **kwargs)
-        return completion.text
+        return [prompt, completion.text]
     
     def _cohere_prompt_completion(self, prompt:str, **kwargs):
         import cohere

--- a/src/privateai_client/components/llm_connector.py
+++ b/src/privateai_client/components/llm_connector.py
@@ -5,13 +5,13 @@ class LLMConnector:
 
     accepted_llms = ["openai", "cohere", "palm", "vertexai"]
         
-    def _vertexai_prompt_completion(self, prompt:str, init_parameters:Dict, chat_model_name:str, chat_parameters: Dict = None, **kwargs):
+    def _vertexai_prompt_completion(self, prompt:str, init_parameters:Dict[str, any], chat_model_name:str, chat_parameters: Dict[str, any] = None, **kwargs):
         import vertexai
         from vertexai.preview.language_models import ChatModel
 
-        vertexai.init(init_parameters)
+        vertexai.init(**init_parameters)
         chat_model = ChatModel.from_pretrained(chat_model_name)
-        chat = chat_model.start_chat(chat_parameters)
+        chat = chat_model.start_chat(**chat_parameters)
         completion = chat.send_message(f'{prompt}', **kwargs)
         return [prompt, completion.text]
     

--- a/src/privateai_client/pai_client.py
+++ b/src/privateai_client/pai_client.py
@@ -3,6 +3,8 @@ from typing import Union
 
 from requests import HTTPError
 
+from .components.llm_connector import LLMConnector
+
 from .components import *
 
 
@@ -27,6 +29,7 @@ class PAIClient:
             self.add_api_key(kwargs["api_key"])
         elif "bearer_token" in kwargs.keys():
             self.add_bearer_token(kwargs["bearer_token"])
+        self.llm_conector = LLMConnector()
 
     def _add_auth(self, auth_type, auth_val):
         auth_header = {}
@@ -155,3 +158,6 @@ class PAIClient:
                 "request_object can only be a dictionary or a BleepRequest object"
             )
         return response
+    
+    def send_redacted_prompt(self, prompt:str, llm_model:str, **kwargs):
+        return self.llm_conector.send_redacted_prompt(prompt=prompt, llm_model=llm_model, **kwargs)


### PR DESCRIPTION
### What's Changed?

An LLM wrapper is added. It takes a string as a prompt that is then deidentified. It then gets sent to the LLM, and the response (alongside the original message) is reidentified. Returns a list of strings as a response. Supports OpenAI, Cohere and VertexAI.

Sample commands to test 
llm_response = pai_client.send_redacted_prompt(prompt="My sample name is John Smith", llm_model="openai", model="gpt-3.5-turbo", model_api_key="ADD_MODEL_KEY_HERE")

llm_response = pai_client.send_redacted_prompt(prompt="My sample name is John Smith", llm_model="cohere", model_api_key="ADD_MODEL_KEY_HERE")

llm_response = pai_client.send_redacted_prompt(prompt="My sample name is John Smith", llm_model="vertexai", chat_model_name="chat-bison@001") -- needs to be configured beforehand if I understand correctly.


### PR Checklist

- [ ] Updated unit tests
- [x] Ran unit tests