### PR TITLE
[DEID-1886]: Add reidentify sensitive labels as a parameter for the Reid route

### DIFF
--- a/src/privateai_client/components/request_objects.py
+++ b/src/privateai_client/components/request_objects.py
@@ -62,14 +62,18 @@ class AudioOptions(BaseRequestObject):
 
     def _bleep_start_padding_validator(self, var):
         if type(var) is not float:
-            raise ValueError(f"AudioOptions.bleep_start_padding must be of type float, but got {type(var)}")
+            raise ValueError(
+                f"AudioOptions.bleep_start_padding must be of type float, but got {type(var)}"
+            )
         if var < 0:
             raise ValueError("AudioOptions.bleep_start_padding must be positive")
         return True
 
     def _bleep_end_padding_validator(self, var):
         if type(var) is not float:
-            raise ValueError(f"AudioOptions.bleep_end_padding must be of type float, but got {type(var)}")
+            raise ValueError(
+                f"AudioOptions.bleep_end_padding must be of type float, but got {type(var)}"
+            )
         if var < 0:
             raise ValueError("AudioOptions.bleep_end_padding must be positive")
         return True
@@ -343,7 +347,11 @@ class PDFOptions(BaseRequestObject):
     default_density = 200
     default_max_resolution = 3000
 
-    def __init__(self, density: int = default_density, max_resolution: int = default_max_resolution):
+    def __init__(
+        self,
+        density: int = default_density,
+        max_resolution: int = default_max_resolution,
+    ):
         self._density = density
         self._max_resolution = max_resolution
 
@@ -374,7 +382,6 @@ class PDFOptions(BaseRequestObject):
         if type(var) is not int:
             raise ValueError("PDFOptions.max_resolution must be of type int and >0")
         return True
-
 
     @classmethod
     def fromdict(cls, values: dict):
@@ -804,7 +811,9 @@ class ReidentifyTextRequest(BaseRequestObject):
         processed_text: List[str] = [],
         entities: List[Entity] = [],
         model: str = "",
+        reidentify_sensitive_labels: bool = True,
     ):
+        self.reidentify_sensitive_labels = reidentify_sensitive_labels
         self.processed_text = processed_text
         self.entities = entities
         self.model = model
@@ -823,5 +832,5 @@ class ReidentifyTextRequest(BaseRequestObject):
             return cls._fromdict(initializer_dict)
         except TypeError:
             raise TypeError(
-                "ReidentifyTextRequest can only accept the values 'processed_text', 'entities' and 'model"
+                "ReidentifyTextRequest can only accept the values 'processed_text', 'entities', 'model' and 'reidentify_sensitive_labels'"
             )

--- a/src/privateai_client/components/request_objects.py
+++ b/src/privateai_client/components/request_objects.py
@@ -811,9 +811,9 @@ class ReidentifyTextRequest(BaseRequestObject):
         processed_text: List[str] = [],
         entities: List[Entity] = [],
         model: str = "",
-        reidentify_sensitive_labels: bool = True,
+        reidentify_sensitive_fields: bool = True,
     ):
-        self.reidentify_sensitive_labels = reidentify_sensitive_labels
+        self.reidentify_sensitive_fields = reidentify_sensitive_fields
         self.processed_text = processed_text
         self.entities = entities
         self.model = model
@@ -832,5 +832,5 @@ class ReidentifyTextRequest(BaseRequestObject):
             return cls._fromdict(initializer_dict)
         except TypeError:
             raise TypeError(
-                "ReidentifyTextRequest can only accept the values 'processed_text', 'entities', 'model' and 'reidentify_sensitive_labels'"
+                "ReidentifyTextRequest can only accept the values 'processed_text', 'entities', 'model' and 'reidentify_sensitive_fields'"
             )

--- a/src/privateai_client/pai_client.py
+++ b/src/privateai_client/pai_client.py
@@ -99,7 +99,7 @@ class PAIClient:
                 self.post.reidentify_text(request_object.to_dict())
             )
         elif type(request_object) is dict:
-            response = ReidentifyTextRequest(self.post.process_text(request_object))
+            response = ReidentifyTextRequest(self.post.reidentify_text(request_object))
         else:
             raise ValueError(
                 "request_object can only be a dictionary or a ReidentifyTextRequest object"

--- a/src/privateai_client/tests/test_request_objects.py
+++ b/src/privateai_client/tests/test_request_objects.py
@@ -1056,15 +1056,17 @@ def test_reidentify_text_request_initialize_fromdict():
             "processed_text": processed_text,
             "entities": [row.to_dict() for row in entities],
             "model": model,
+            "reidentify_sensitive_labels": False,
         }
     )
     assert reid.processed_text == ["this is a test"]
     assert reid.entities[0].text == "Hola"
     assert reid.model == "gpt-700.2-ultra-turbo"
+    assert reid.reidentify_sensitive_labels == False
 
 
 def test_reidentify_text_request_invalid_initialize_fromdict():
-    error_msg = "ReidentifyTextRequest can only accept the values 'processed_text', 'entities' and 'model"
+    error_msg = "ReidentifyTextRequest can only accept the values 'processed_text', 'entities', 'model' and 'reidentify_sensitive_labels'"
     processed_text = ["this is a test"]
     entities = [Entity(processed_text="NAME", text="Hola")]
     model = "gpt-700.2-ultra-turbo"
@@ -1084,12 +1086,17 @@ def test_reidentify_text_request_to_dict():
     processed_text = ["this is a test"]
     entities = [Entity(processed_text="NAME", text="Hola")]
     model = "gpt-700.2-ultra-turbo"
+    reidentify_sensitive_labels = False
     reid = ReidentifyTextRequest(
-        processed_text=processed_text, entities=entities, model=model
+        processed_text=processed_text,
+        entities=entities,
+        model=model,
+        reidentify_sensitive_labels=reidentify_sensitive_labels,
     ).to_dict()
     assert reid["processed_text"][0] == "this is a test"
     assert reid["entities"][0]["text"] == "Hola"
     assert reid["model"] == "gpt-700.2-ultra-turbo"
+    assert reid["reidentify_sensitive_labels"] == reidentify_sensitive_labels
 
 
 def test_synthetic_text():

--- a/src/privateai_client/tests/test_request_objects.py
+++ b/src/privateai_client/tests/test_request_objects.py
@@ -524,9 +524,9 @@ def test_audio_options_default_initializer():
 
 
 def test_audio_options_initializer():
-    audio_options = AudioOptions(bleep_start_padding=200., bleep_end_padding=300.)
-    assert audio_options.bleep_start_padding == 200.
-    assert audio_options.bleep_end_padding == 300.
+    audio_options = AudioOptions(bleep_start_padding=200.0, bleep_end_padding=300.0)
+    assert audio_options.bleep_start_padding == 200.0
+    assert audio_options.bleep_end_padding == 300.0
 
 
 def test_audio_options_initialize_fromdict():
@@ -548,11 +548,11 @@ def test_audio_options_invalid_initialize_fromdict():
 
 def test_audio_options_setters():
     audio_options = AudioOptions()
-    audio_options.bleep_end_padding = 1.
-    audio_options.bleep_start_padding = 2.
+    audio_options.bleep_end_padding = 1.0
+    audio_options.bleep_start_padding = 2.0
 
-    assert audio_options.bleep_end_padding == 1.
-    assert audio_options.bleep_start_padding == 2.
+    assert audio_options.bleep_end_padding == 1.0
+    assert audio_options.bleep_start_padding == 2.0
 
 
 def test_audio_options_bleep_start_padding_validator():
@@ -793,7 +793,7 @@ def test_process_file_uri_request_initializer():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     process_file_uri_obj = ProcessFileUriRequest(
         uri="this/location/right/here.png",
         entity_detection=entity_detection,
@@ -803,7 +803,7 @@ def test_process_file_uri_request_initializer():
     assert process_file_uri_obj.uri == "this/location/right/here.png"
     assert process_file_uri_obj.entity_detection.accuracy == "standard"
     assert process_file_uri_obj.pdf_options.density == 100
-    assert process_file_uri_obj.audio_options.bleep_end_padding == 2.
+    assert process_file_uri_obj.audio_options.bleep_end_padding == 2.0
 
 
 def test_process_file_uri_request_initialize_fromdict():
@@ -816,7 +816,7 @@ def test_process_file_uri_request_initialize_fromdict():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     process_file_uri_obj = ProcessFileUriRequest.fromdict(
         {
             "uri": "this/location/right/here.png",
@@ -828,7 +828,7 @@ def test_process_file_uri_request_initialize_fromdict():
     assert process_file_uri_obj.uri == "this/location/right/here.png"
     assert process_file_uri_obj.entity_detection.accuracy == "standard"
     assert process_file_uri_obj.pdf_options.density == 100
-    assert process_file_uri_obj.audio_options.bleep_end_padding == 2.
+    assert process_file_uri_obj.audio_options.bleep_end_padding == 2.0
 
 
 def test_process_file_uri_request_invalid_initialize_fromdict():
@@ -842,7 +842,7 @@ def test_process_file_uri_request_invalid_initialize_fromdict():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     with pytest.raises(TypeError) as excinfo:
         ProcessFileUriRequest.fromdict(
             {
@@ -866,7 +866,7 @@ def test_process_file_uri_request_to_dict():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     process_file_uri_obj = ProcessFileUriRequest(
         uri="this/location/right/here.png",
         entity_detection=entity_detection,
@@ -876,7 +876,7 @@ def test_process_file_uri_request_to_dict():
     assert process_file_uri_obj["uri"] == "this/location/right/here.png"
     assert process_file_uri_obj["entity_detection"]["accuracy"] == "standard"
     assert process_file_uri_obj["pdf_options"]["density"] == 100
-    assert process_file_uri_obj["audio_options"]["bleep_end_padding"] == 2.
+    assert process_file_uri_obj["audio_options"]["bleep_end_padding"] == 2.0
 
 
 # Process File Base64 Request Tests
@@ -900,7 +900,7 @@ def test_process_file_base64_request_initializer():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     process_file_base64_request_obj = ProcessFileBase64Request(
         file="sfsfxe234jkjsdlkfnDATA",
         entity_detection=entity_detection,
@@ -910,7 +910,7 @@ def test_process_file_base64_request_initializer():
     assert process_file_base64_request_obj.file == "sfsfxe234jkjsdlkfnDATA"
     assert process_file_base64_request_obj.entity_detection.accuracy == "standard"
     assert process_file_base64_request_obj.pdf_options.density == 100
-    assert process_file_base64_request_obj.audio_options.bleep_end_padding == 2.
+    assert process_file_base64_request_obj.audio_options.bleep_end_padding == 2.0
 
 
 def test_process_file_base64_request_initialize_fromdict():
@@ -924,7 +924,7 @@ def test_process_file_base64_request_initialize_fromdict():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     process_file_base64_request_obj = ProcessFileBase64Request.fromdict(
         {
             "file": file.to_dict(),
@@ -936,7 +936,7 @@ def test_process_file_base64_request_initialize_fromdict():
     assert process_file_base64_request_obj.file.data == "sfsfxe234jkjsdlkfnDATA"
     assert process_file_base64_request_obj.entity_detection.accuracy == "standard"
     assert process_file_base64_request_obj.pdf_options.density == 100
-    assert process_file_base64_request_obj.audio_options.bleep_end_padding == 2.
+    assert process_file_base64_request_obj.audio_options.bleep_end_padding == 2.0
 
 
 def test_process_file_base64_request_invalid_initialize_fromdict():
@@ -951,7 +951,7 @@ def test_process_file_base64_request_invalid_initialize_fromdict():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     with pytest.raises(TypeError) as excinfo:
         ProcessFileBase64Request.fromdict(
             {
@@ -975,7 +975,7 @@ def test_process_file_base64_request_to_dict():
         return_entity=False,
     )
     pdf_options = PDFOptions(density=100)
-    audio_options = AudioOptions(bleep_start_padding=1., bleep_end_padding=2.)
+    audio_options = AudioOptions(bleep_start_padding=1.0, bleep_end_padding=2.0)
     process_file_base64_request_obj = ProcessFileBase64Request(
         file="sfsfxe234jkjsdlkfnDATA",
         entity_detection=entity_detection,
@@ -985,7 +985,7 @@ def test_process_file_base64_request_to_dict():
     assert process_file_base64_request_obj["file"] == "sfsfxe234jkjsdlkfnDATA"
     assert process_file_base64_request_obj["entity_detection"]["accuracy"] == "standard"
     assert process_file_base64_request_obj["pdf_options"]["density"] == 100
-    assert process_file_base64_request_obj["audio_options"]["bleep_end_padding"] == 2.
+    assert process_file_base64_request_obj["audio_options"]["bleep_end_padding"] == 2.0
 
 
 # Bleep Request Tests
@@ -1036,11 +1036,15 @@ def test_reidentify_text_request_initializer():
     entities = [Entity(processed_text="NAME", text="Hola")]
     model = "gpt-700.2-ultra-turbo"
     reid = ReidentifyTextRequest(
-        processed_text=processed_text, entities=entities, model=model
+        processed_text=processed_text,
+        entities=entities,
+        model=model,
+        reidentify_sensitive_labels=True,
     )
     assert reid.processed_text == ["this is a test"]
     assert reid.entities[0].text == "Hola"
     assert reid.model == "gpt-700.2-ultra-turbo"
+    assert reid.reidentify_sensitive_labels == True
 
 
 def test_reidentify_text_request_initialize_fromdict():

--- a/src/privateai_client/tests/test_request_objects.py
+++ b/src/privateai_client/tests/test_request_objects.py
@@ -1039,12 +1039,12 @@ def test_reidentify_text_request_initializer():
         processed_text=processed_text,
         entities=entities,
         model=model,
-        reidentify_sensitive_labels=True,
+        reidentify_sensitive_fields=True,
     )
     assert reid.processed_text == ["this is a test"]
     assert reid.entities[0].text == "Hola"
     assert reid.model == "gpt-700.2-ultra-turbo"
-    assert reid.reidentify_sensitive_labels == True
+    assert reid.reidentify_sensitive_fields == True
 
 
 def test_reidentify_text_request_initialize_fromdict():
@@ -1056,17 +1056,17 @@ def test_reidentify_text_request_initialize_fromdict():
             "processed_text": processed_text,
             "entities": [row.to_dict() for row in entities],
             "model": model,
-            "reidentify_sensitive_labels": False,
+            "reidentify_sensitive_fields": False,
         }
     )
     assert reid.processed_text == ["this is a test"]
     assert reid.entities[0].text == "Hola"
     assert reid.model == "gpt-700.2-ultra-turbo"
-    assert reid.reidentify_sensitive_labels == False
+    assert reid.reidentify_sensitive_fields == False
 
 
 def test_reidentify_text_request_invalid_initialize_fromdict():
-    error_msg = "ReidentifyTextRequest can only accept the values 'processed_text', 'entities', 'model' and 'reidentify_sensitive_labels'"
+    error_msg = "ReidentifyTextRequest can only accept the values 'processed_text', 'entities', 'model' and 'reidentify_sensitive_fields'"
     processed_text = ["this is a test"]
     entities = [Entity(processed_text="NAME", text="Hola")]
     model = "gpt-700.2-ultra-turbo"
@@ -1086,17 +1086,17 @@ def test_reidentify_text_request_to_dict():
     processed_text = ["this is a test"]
     entities = [Entity(processed_text="NAME", text="Hola")]
     model = "gpt-700.2-ultra-turbo"
-    reidentify_sensitive_labels = False
+    reidentify_sensitive_fields = False
     reid = ReidentifyTextRequest(
         processed_text=processed_text,
         entities=entities,
         model=model,
-        reidentify_sensitive_labels=reidentify_sensitive_labels,
+        reidentify_sensitive_fields=reidentify_sensitive_fields,
     ).to_dict()
     assert reid["processed_text"][0] == "this is a test"
     assert reid["entities"][0]["text"] == "Hola"
     assert reid["model"] == "gpt-700.2-ultra-turbo"
-    assert reid["reidentify_sensitive_labels"] == reidentify_sensitive_labels
+    assert reid["reidentify_sensitive_fields"] == reidentify_sensitive_fields
 
 
 def test_synthetic_text():


### PR DESCRIPTION
### What's Changed?
- Add reidentify sensitive labels as a parameter for the Reid route, default it to `True`. 
- Small bug fix, called the Reid route with an obj was calling processed text instead of reidentify text. 

### PR Checklist

- [x] Updated unit tests
- [x] Ran unit tests