### PR TITLE
Bumped requests library to 2.32.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Added
 
 ### Changed
+- Bumped requests from 2.31.0 to 2.32.3
 
 ### Fixed
 
@@ -13,6 +14,7 @@
 - Added NER route support
 - Added `image_options` support
     - Using `image_options_obj`, the `masking_method` can be set to `blur` or `blackbox`.
+
 ### Changed
 
 ### Fixed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests~=2.31.0
+requests~=2.32.3


### PR DESCRIPTION
### What's Changed?
- Bumped requests library to 2.32.3 to resolve security alert

Note: The severity is medium, so this will be included in the next thin client release.

### PR Checklist

- [ ] Updated unit tests
- [X] Ran unit tests