### PR TITLE
Update coreference resolution to accept "model_prediction"

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ sample_entity_type_selector = request_objects.entity_type_selector_obj(type="DIS
 sample_entity_detection = request_objects.entity_detection_obj(entity_types=[sample_entity_type_selector])
 
 # sub-dictionary of a process text request
-sample_processed_text = request_objects.processed_text_obj(type="MARKER", pattern="[UNIQUE_NUMBERED_ENTITY_TYPE]", coreference_resolution="model")
+sample_processed_text = request_objects.processed_text_obj(type="MARKER", pattern="[UNIQUE_NUMBERED_ENTITY_TYPE]", coreference_resolution="model_prediction")
 
 # request object created using the sub-dictionaries
 sample_request = request_objects.process_text_obj(text=[sample_text], entity_detection=sample_entity_detection, processed_text=sample_processed_text)

--- a/src/privateai_client/components/request_objects.py
+++ b/src/privateai_client/components/request_objects.py
@@ -514,7 +514,12 @@ class PDFOptions(BaseRequestObject):
 
 class OCROptions(BaseRequestObject):
     default_ocr_system = "paddleocr"
-    VALID_OCR_SYSTEM = ["azure_computer_vision", "azure_doc_intelligence", "hybrid", "paddleocr"]
+    VALID_OCR_SYSTEM = [
+        "azure_computer_vision",
+        "azure_doc_intelligence",
+        "hybrid",
+        "paddleocr",
+    ]
 
     def __init__(
         self,
@@ -543,9 +548,8 @@ class OCROptions(BaseRequestObject):
         try:
             return cls._fromdict(values)
         except TypeError:
-            raise TypeError(
-                "OCROptions can only accept 'ocr_system'"
-            )
+            raise TypeError("OCROptions can only accept 'ocr_system'")
+
 
 class ProcessedMarkerText(BaseRequestObject):
     attributes = ["_pattern"]
@@ -559,7 +563,7 @@ class ProcessedMarkerText(BaseRequestObject):
     default_marker_language = "en"
     valid_marker_languages = ["auto", "en", "fr", "de", "ja", "ko", "nl", "ru", "uk"]
     default_coreference_resolution = "heuristics"
-    valid_coreference_resolutions = ["heuristics", "model", "combined"]
+    valid_coreference_resolutions = ["heuristics", "model_prediction", "combined"]
 
     def __init__(
         self,

--- a/src/privateai_client/tests/test_integration.py
+++ b/src/privateai_client/tests/test_integration.py
@@ -37,6 +37,45 @@ def test_entity_detection_default():
     assert resp.ok
 
 
+def test_entity_detection_coref_model_prediction():
+    client = _get_client()
+    req = rq.process_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        processed_text=rq.processed_text_obj(
+            type="MARKER", coreference_resolution="model_prediction"
+        ),
+    )
+    resp = client.process_text(req)
+    assert resp.ok
+
+
+def test_entity_detection_coref_heuristic():
+    client = _get_client()
+    req = rq.process_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        processed_text=rq.processed_text_obj(
+            type="MARKER", coreference_resolution="heuristics"
+        ),
+    )
+    resp = client.process_text(req)
+    assert resp.ok
+
+
+def test_entity_detection_coref_combined():
+    client = _get_client()
+    req = rq.process_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        processed_text=rq.processed_text_obj(
+            type="MARKER", coreference_resolution="combined"
+        ),
+    )
+    resp = client.process_text(req)
+    assert resp.ok
+
+
 def test_entity_detection_with_enable_entity_types():
     client = _get_client()
     selector = rq.entity_type_selector_obj(type="ENABLE", value=["HIPAA_SAFE_HARBOR"])
@@ -280,7 +319,9 @@ def test_process_ocr_image_file_base64():
     file_obj = rq.file_obj(data=file_data, content_type=file_type)
     image_option_obj = rq.image_options_obj(masking_method="blur", palette=True)
     ocr_option_obj = rq.ocr_options_obj(ocr_system="azure_doc_intelligence")
-    request_obj = rq.file_base64_obj(file=file_obj, image_options=image_option_obj, ocr_options=ocr_option_obj)
+    request_obj = rq.file_base64_obj(
+        file=file_obj, image_options=image_option_obj, ocr_options=ocr_option_obj
+    )
     resp = client.process_files_base64(request_object=request_obj)
     assert resp.ok
 

--- a/src/privateai_client/tests/test_request_objects.py
+++ b/src/privateai_client/tests/test_request_objects.py
@@ -415,9 +415,11 @@ def test_processed_text_mask_initializer():
 
 
 def test_processed_text_coreference_initializer():
-    processed_text = ProcessedText(type="MARKER", coreference_resolution="model")
+    processed_text = ProcessedText(
+        type="MARKER", coreference_resolution="model_prediction"
+    )
     assert processed_text.type == "MARKER"
-    assert processed_text.coreference_resolution == "model"
+    assert processed_text.coreference_resolution == "model_prediction"
 
 
 def test_processed_text_initialize_fromdict():
@@ -464,11 +466,11 @@ def test_processed_text_coreference_setters():
     processed_text.type = "MARKER"
     processed_text.pattern = "[UNIQUE_NUMBERED_ENTITY_TYPE]"
     processed_text.marker_language = "fr"
-    processed_text.coreference_resolution = "model"
+    processed_text.coreference_resolution = "model_prediction"
     assert processed_text.type == "MARKER"
     assert processed_text.pattern == "[UNIQUE_NUMBERED_ENTITY_TYPE]"
     assert processed_text.marker_language == "fr"
-    assert processed_text.coreference_resolution == "model"
+    assert processed_text.coreference_resolution == "model_prediction"
 
 
 def test_processed_text_type_validator():
@@ -775,16 +777,12 @@ def test_ocr_options_default_initializer():
 
 
 def test_ocr_options_initializer():
-    ocr_options = OCROptions(
-        ocr_system="azure_doc_intelligence"
-    )
+    ocr_options = OCROptions(ocr_system="azure_doc_intelligence")
     assert ocr_options.ocr_system == "azure_doc_intelligence"
 
 
 def test_ocr_options_initialize_fromdict():
-    ocr_options = OCROptions.fromdict(
-        {"ocr_system": "azure_doc_intelligence"}
-    )
+    ocr_options = OCROptions.fromdict({"ocr_system": "azure_doc_intelligence"})
     assert ocr_options.ocr_system == "azure_doc_intelligence"
 
 


### PR DESCRIPTION
### What's Changed?
- Updated the `valid_coreference_resolutions` list to accept "model_prediction", instead of "model", as expected by the process/text endpoint.

### PR Checklist

- [x] Updated unit tests
- [x] Ran unit tests