### PR TITLE
Add relation detection in analyze/text

### DIFF
--- a/src/privateai_client/components/request_objects.py
+++ b/src/privateai_client/components/request_objects.py
@@ -970,6 +970,37 @@ class ObjectEntityDetection(BaseRequestObject):
             )
 
 
+class RelationDetection(BaseRequestObject):
+    default_coreference_resolution = "heuristics"
+    valid_coreference_resolutions = ["heuristics", "model_prediction", "combined"]
+
+    def __init__(self, coreference_resolution: str):
+        self._coreference_resolution = coreference_resolution
+
+    @property
+    def coreference_resolution(self):
+        return self._coreference_resolution
+
+    def _coreference_resolution_validator(self, var):
+        if var not in self.valid_coreference_resolutions:
+            raise ValueError(
+                f"{var} is not valid. RelationDetection.coreference_resolution can only be one of the following: {', '.join(self.valid_coreference_resolutions)}"
+            )
+        return True
+
+    @classmethod
+    def fromdict(cls, values: dict):
+        try:
+            initializer_dict = {}
+            for key, value in values.items():
+                initializer_dict[key] = value
+            return cls._fromdict(initializer_dict)
+        except TypeError:
+            raise TypeError(
+                "RelationDetection can only accept the value 'coreference_resolution'"
+            )
+
+
 class ProcessTextRequest(BaseRequestObject):
     def __init__(
         self,
@@ -1036,16 +1067,18 @@ class AnalyzeTextRequest(BaseRequestObject):
     def __init__(
         self,
         text: List[str],
-        locale: str,
+        locale: Optional[str] = None,
         link_batch: Optional[bool] = None,
         entity_detection: Optional[EntityDetection] = None,
         project_id: Optional[str] = None,
+        relation_detection: Optional[RelationDetection] = None,
     ):
         self.text = text
         self.locale = locale
         self.link_batch = link_batch
         self.entity_detection = entity_detection
         self.project_id = project_id
+        self.relation_detection = relation_detection
 
     @classmethod
     def fromdict(cls, values: dict):
@@ -1054,12 +1087,15 @@ class AnalyzeTextRequest(BaseRequestObject):
             for key, value in values.items():
                 if key == "entity_detection":
                     initializer_dict[key] = EntityDetection.fromdict(value)
+                elif key == "relation_detection":
+                    initializer_dict[key] = RelationDetection.fromdict(value)
                 else:
                     initializer_dict[key] = value
+
             return cls._fromdict(initializer_dict)
         except TypeError:
             raise TypeError(
-                "AnalyzeTextRequest can only accept the values 'text', 'locale', 'link_batch' and 'entity_detection'"
+                "AnalyzeTextRequest can only accept the values 'text', 'locale', 'link_batch', 'entity_detection' and 'relation_detection'"
             )
 
 

--- a/src/privateai_client/components/request_objects.py
+++ b/src/privateai_client/components/request_objects.py
@@ -971,20 +971,30 @@ class ObjectEntityDetection(BaseRequestObject):
 
 
 class RelationDetection(BaseRequestObject):
-    default_coreference_resolution = "heuristics"
+    default_coreference_resolution = None
     valid_coreference_resolutions = ["heuristics", "model_prediction", "combined"]
 
-    def __init__(self, coreference_resolution: str):
-        self._coreference_resolution = coreference_resolution
+    def __init__(
+        self, coreference_resolution: Optional[str] = default_coreference_resolution
+    ):
+        if self._coreference_resolution_validator:
+            self._coreference_resolution = coreference_resolution
 
     @property
     def coreference_resolution(self):
         return self._coreference_resolution
 
+    @coreference_resolution.setter
+    def coreference_resolution(self, var):
+        if self._coreference_resolution_validator(var):
+            self._coreference_resolution = var
+
     def _coreference_resolution_validator(self, var):
+        if var is None:
+            return True
         if var not in self.valid_coreference_resolutions:
             raise ValueError(
-                f"{var} is not valid. RelationDetection.coreference_resolution can only be one of the following: {', '.join(self.valid_coreference_resolutions)}"
+                f"{var} is not valid. RelationDetection.coreference_resolution can only be one of the following: {', '.join(self.valid_coreference_resolutions)} or None"
             )
         return True
 

--- a/src/privateai_client/objects.py
+++ b/src/privateai_client/objects.py
@@ -22,3 +22,4 @@ class request_objects:
     processed_text_obj = req_objects.ProcessedText
     reidentify_text_obj = req_objects.ReidentifyTextRequest
     timestamp_obj = req_objects.Timestamp
+    relation_detection_obj = req_objects.RelationDetection

--- a/src/privateai_client/tests/test_integration.py
+++ b/src/privateai_client/tests/test_integration.py
@@ -594,3 +594,40 @@ def test_analyze_full_entity_detection():
     )
     resp = client.analyze_text(req)
     assert resp.ok
+
+
+def test_analyze_coref_model_prediction():
+    client = _get_client()
+    req = rq.analyze_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        relation_detection=rq.relation_detection_obj(
+            coreference_resolution="model_prediction"
+        ),
+    )
+    resp = client.analyze_text(req)
+    assert resp.ok
+
+
+def test_analyze_coref_heuristic():
+    client = _get_client()
+    req = rq.analyze_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        relation_detection=rq.relation_detection_obj(
+            coreference_resolution="heuristics"
+        ),
+    )
+    resp = client.analyze_text(req)
+    assert resp.ok
+
+
+def test_analyze_coref_combined():
+    client = _get_client()
+    req = rq.analyze_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        relation_detection=rq.relation_detection_obj(coreference_resolution="combined"),
+    )
+    resp = client.analyze_text(req)
+    assert resp.ok

--- a/src/privateai_client/tests/test_request_objects.py
+++ b/src/privateai_client/tests/test_request_objects.py
@@ -470,7 +470,7 @@ def test_object_entity_detection_default_initializer():
 
 def test_object_entity_detection_initializer():
     object_entity_detection_obj = ObjectEntityDetection(
-        object_entity_types=[ObjectEntityTypeSelector(type="ENABLE")],
+        object_entity_types=[ObjectEntityTypeSelector(type="ENABLE")]
     )
     assert (
         type(object_entity_detection_obj.object_entity_types[0])
@@ -480,9 +480,7 @@ def test_object_entity_detection_initializer():
 
 def test_object_entity_detection_initialize_fromdict():
     object_entity_detection = ObjectEntityDetection.fromdict(
-        {
-            "object_entity_types": [ObjectEntityTypeSelector(type="ENABLE").to_dict()],
-        }
+        {"object_entity_types": [ObjectEntityTypeSelector(type="ENABLE").to_dict()]}
     )
     assert (
         type(object_entity_detection.object_entity_types[0]) is ObjectEntityTypeSelector
@@ -506,15 +504,13 @@ def test_object_entity_detection_invalid_initialize_fromdict():
 def test_object_entity_detection_object_entity_types_validator():
     error_msg = "ObjectEntityDetection.object_entity_types can only contain ObjectEntityTypeSelector objects"
     with pytest.raises(ValueError) as excinfo:
-        ObjectEntityDetection(
-            object_entity_types=["junk"],
-        )
+        ObjectEntityDetection(object_entity_types=["junk"])
     assert error_msg in str(excinfo.value)
 
 
 def test_object_entity_detection_to_dict():
     object_entity_detection_obj = ObjectEntityDetection(
-        object_entity_types=[ObjectEntityTypeSelector(type="ENABLE")],
+        object_entity_types=[ObjectEntityTypeSelector(type="ENABLE")]
     ).to_dict()
     assert type(object_entity_detection_obj["object_entity_types"][0]) is dict
 
@@ -855,11 +851,7 @@ def test_image_options_invalid_initialize_fromdict():
     error_msg = "ImageOptions can only accept the values 'masking_method' and 'palette'"
     with pytest.raises(TypeError) as excinfo:
         ImageOptions.fromdict(
-            {
-                "masking_method": "blur",
-                "palette": True,
-                "junk": "value",
-            }
+            {"masking_method": "blur", "palette": True, "junk": "value"}
         )
     assert error_msg in str(excinfo.value)
 
@@ -976,6 +968,54 @@ def test_timestamp_to_dict():
     timestamp = Timestamp(start=2.0, end=3.0).to_dict()
     assert timestamp["start"] == 2.0
     assert timestamp["end"] == 3.0
+
+
+# Relation Detection Tests
+def test_relation_detection_default_initializer():
+    relation_detection = RelationDetection()
+    assert relation_detection.coreference_resolution is None
+
+
+def test_relation_detection_initializer():
+    relation_detection = RelationDetection(coreference_resolution="model_prediction")
+    assert relation_detection.coreference_resolution == "model_prediction"
+
+
+def test_relation_detection_initialize_fromdict():
+    relation_detection = RelationDetection.fromdict(
+        {"coreference_resolution": "combined"}
+    )
+    assert relation_detection.coreference_resolution == "combined"
+
+
+def test_relation_detection_invalid_initialize_fromdict():
+    error_msg = "RelationDetection can only accept the value 'coreference_resolution'"
+    with pytest.raises(TypeError) as excinfo:
+        RelationDetection.fromdict(
+            {"coreference_resolution": "combined", "junk": "value"}
+        )
+    assert error_msg in str(excinfo.value)
+
+
+def test_relation_detection_setters():
+    relation_detection = RelationDetection()
+    relation_detection.coreference_resolution = "combined"
+    assert relation_detection.coreference_resolution == "combined"
+
+
+def test_relation_detection_coreference_resolution_validator():
+    error_msg = "junk is not valid. RelationDetection.coreference_resolution can only be one of the following: heuristics, model_prediction, combined or None"
+    relation_detection = RelationDetection()
+    with pytest.raises(ValueError) as excinfo:
+        relation_detection.coreference_resolution = "junk"
+    assert error_msg in str(excinfo.value)
+
+
+def test_relation_detection_to_dict():
+    relation_detection = RelationDetection(
+        coreference_resolution="model_prediction"
+    ).to_dict()
+    assert relation_detection["coreference_resolution"] == "model_prediction"
 
 
 # Process Text Request Tests
@@ -1149,9 +1189,7 @@ def test_ner_text_request_initializer():
     )
 
     ner_text_request = NerTextRequest(
-        text=text,
-        link_batch=link_batch,
-        entity_detection=entity_detection,
+        text=text, link_batch=link_batch, entity_detection=entity_detection
     )
 
     assert ner_text_request.text == text
@@ -1230,9 +1268,7 @@ def test_ner_text_request_to_dict():
     )
 
     ner_text_request = NerTextRequest(
-        text=text,
-        link_batch=link_batch,
-        entity_detection=entity_detection,
+        text=text, link_batch=link_batch, entity_detection=entity_detection
     ).to_dict()
     assert ner_text_request["text"] == text
     assert ner_text_request["link_batch"] == link_batch
@@ -1273,9 +1309,7 @@ def test_analyze_text_request_initializer():
         filter=[filter],
         return_entity=False,
     )
-    relation_detection = RelationDetection(
-        coreference_resolution="model_prediction",
-    )
+    relation_detection = RelationDetection(coreference_resolution="model_prediction")
 
     analyze_text_request = AnalyzeTextRequest(
         text=text,
@@ -1440,7 +1474,7 @@ def test_process_file_uri_request_initializer():
     )
     object_entity_type = ObjectEntityTypeSelector(type="ENABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     process_file_uri_obj = ProcessFileUriRequest(
         uri="this/location/right/here.png",
@@ -1479,7 +1513,7 @@ def test_process_file_uri_request_initialize_fromdict():
     )
     object_entity_type = ObjectEntityTypeSelector(type="ENABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     ocr_options = OCROptions(ocr_system="azure_computer_vision")
     process_file_uri_obj = ProcessFileUriRequest.fromdict(
@@ -1524,7 +1558,7 @@ def test_process_file_uri_request_invalid_initialize_fromdict():
     )
     object_entity_type = ObjectEntityTypeSelector(type="ENABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     ocr_options = OCROptions(ocr_system="azure_computer_vision")
     with pytest.raises(TypeError) as excinfo:
@@ -1560,7 +1594,7 @@ def test_process_file_uri_request_to_dict():
     )
     object_entity_type = ObjectEntityTypeSelector(type="ENABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     process_file_uri_obj = ProcessFileUriRequest(
         uri="this/location/right/here.png",
@@ -1613,7 +1647,7 @@ def test_process_file_base64_request_initializer():
     )
     object_entity_type = ObjectEntityTypeSelector(type="ENABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     process_file_base64_request_obj = ProcessFileBase64Request(
         file="sfsfxe234jkjsdlkfnDATA",
@@ -1655,7 +1689,7 @@ def test_process_file_base64_request_initialize_fromdict():
     )
     object_entity_type = ObjectEntityTypeSelector(type="ENABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     process_file_base64_request_obj = ProcessFileBase64Request.fromdict(
         {
@@ -1700,7 +1734,7 @@ def test_process_file_base64_request_invalid_initialize_fromdict():
     )
     object_entity_type = ObjectEntityTypeSelector(type="ENABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     ocr_options = OCROptions(ocr_system="azure_computer_vision")
     with pytest.raises(TypeError) as excinfo:
@@ -1736,7 +1770,7 @@ def test_process_file_base64_request_to_dict():
     )
     object_entity_type = ObjectEntityTypeSelector(type="DISABLE", value=["LOGO"])
     object_entity_detection = ObjectEntityDetection(
-        object_entity_types=[object_entity_type],
+        object_entity_types=[object_entity_type]
     )
     process_file_base64_request_obj = ProcessFileBase64Request(
         file="sfsfxe234jkjsdlkfnDATA",
@@ -1922,10 +1956,7 @@ def test_synthetic_invalid_accuracy_initialize():
 
 def test_synthetic_invalid_accuracy():
     error_msg = "Synthetic Entity Accuracy can only accept values"
-    processed_text = ProcessedText(
-        type="SYNTHETIC",
-        preserve_relationships=True,
-    )
+    processed_text = ProcessedText(type="SYNTHETIC", preserve_relationships=True)
     with pytest.raises(ValueError) as excinfo:
         processed_text.synthetic_entity_accuracy = "invalid"
     assert error_msg in str(excinfo.value)

--- a/src/privateai_client/tests/test_request_objects.py
+++ b/src/privateai_client/tests/test_request_objects.py
@@ -1105,7 +1105,6 @@ def test_process_text_request_to_dict():
         entity_detection=entity_detection,
         processed_text=processed_text,
     ).to_dict()
-    print(process_text_request)
     assert process_text_request["text"] == text
     assert process_text_request["link_batch"] == link_batch
     assert (
@@ -1235,7 +1234,6 @@ def test_ner_text_request_to_dict():
         link_batch=link_batch,
         entity_detection=entity_detection,
     ).to_dict()
-    print(ner_text_request)
     assert ner_text_request["text"] == text
     assert ner_text_request["link_batch"] == link_batch
     assert ner_text_request["entity_detection"]["accuracy"] == entity_detection.accuracy
@@ -1260,6 +1258,7 @@ def test_analyze_text_request_default_initializer():
     assert analyze_text_request.locale == "en-US"
     assert analyze_text_request.link_batch is None
     assert analyze_text_request.entity_detection is None
+    assert analyze_text_request.relation_detection is None
 
 
 def test_analyze_text_request_initializer():
@@ -1274,12 +1273,16 @@ def test_analyze_text_request_initializer():
         filter=[filter],
         return_entity=False,
     )
+    relation_detection = RelationDetection(
+        coreference_resolution="model_prediction",
+    )
 
     analyze_text_request = AnalyzeTextRequest(
         text=text,
         locale=locale,
         link_batch=link_batch,
         entity_detection=entity_detection,
+        relation_detection=relation_detection,
     )
 
     assert analyze_text_request.text == text
@@ -1294,6 +1297,10 @@ def test_analyze_text_request_initializer():
     )
     assert analyze_text_request.entity_detection.filter[0].type == filter.type
     assert analyze_text_request.entity_detection.filter[0].pattern == filter.pattern
+    assert (
+        analyze_text_request.relation_detection.coreference_resolution
+        == relation_detection.coreference_resolution
+    )
 
 
 def test_analyze_text_request_initialize_fromdict():
@@ -1307,6 +1314,7 @@ def test_analyze_text_request_initialize_fromdict():
             "filter": [{"type": "BLOCK", "pattern": "Roger", "entity_type": "TEST"}],
             "return_entity": False,
         },
+        "relation_detection": {"coreference_resolution": "combined"},
     }
     analyze_text_request = AnalyzeTextRequest.fromdict(request_obj)
     assert analyze_text_request.text == request_obj["text"]
@@ -1332,10 +1340,14 @@ def test_analyze_text_request_initialize_fromdict():
         analyze_text_request.entity_detection.filter[0].pattern
         == request_obj["entity_detection"]["filter"][0]["pattern"]
     )
+    assert (
+        analyze_text_request.relation_detection.coreference_resolution
+        == request_obj["relation_detection"]["coreference_resolution"]
+    )
 
 
 def test_analyze_text_request_invalid_initialize_fromdict():
-    error_msg = "AnalyzeTextRequest can only accept the values 'text', 'locale', 'link_batch' and 'entity_detection'"
+    error_msg = "AnalyzeTextRequest can only accept the values 'text', 'locale', 'link_batch', 'entity_detection' and 'relation_detection'"
     request_obj = {
         "text": ["hey!"],
         "link_batch": False,
@@ -1345,6 +1357,7 @@ def test_analyze_text_request_invalid_initialize_fromdict():
             "filter": [{"type": "BLOCK", "pattern": "Roger"}],
             "return_entity": False,
         },
+        "relation_detection": {"coreference_resolution": "model_prediction"},
         "junk": "value",
     }
     with pytest.raises(TypeError) as excinfo:
@@ -1364,14 +1377,15 @@ def test_analyze_text_request_to_dict():
         filter=[filter],
         return_entity=False,
     )
+    relation_detection = RelationDetection(coreference_resolution="heuristics")
 
     analyze_text_request = AnalyzeTextRequest(
         text=text,
         locale=locale,
         link_batch=link_batch,
         entity_detection=entity_detection,
+        relation_detection=relation_detection,
     ).to_dict()
-    print(analyze_text_request)
     assert analyze_text_request["text"] == text
     assert analyze_text_request["locale"] == locale
     assert analyze_text_request["link_batch"] == link_batch
@@ -1391,6 +1405,10 @@ def test_analyze_text_request_to_dict():
     assert (
         analyze_text_request["entity_detection"]["filter"][0]["pattern"]
         == filter.pattern
+    )
+    assert (
+        analyze_text_request["relation_detection"]["coreference_resolution"]
+        == "heuristics"
     )
 
 


### PR DESCRIPTION
### What's Changed?

- Added support for `relation_detection` in the analyze/text route, so coref can be enabled
- Updated locale field to be optional
### PR Checklist

- [x] Updated unit tests
- [x] Ran unit tests