### PR TITLE
Add support for enable_relation_extraction field

### DIFF
--- a/src/privateai_client/components/request_objects.py
+++ b/src/privateai_client/components/request_objects.py
@@ -975,10 +975,14 @@ class RelationDetection(BaseRequestObject):
     valid_coreference_resolutions = ["heuristics", "model_prediction", "combined"]
 
     def __init__(
-        self, coreference_resolution: Optional[str] = default_coreference_resolution
+        self,
+        coreference_resolution: Optional[str] = default_coreference_resolution,
+        enable_relation_extraction: Optional[bool] = False,
     ):
-        if self._coreference_resolution_validator:
+        if self._coreference_resolution_validator(coreference_resolution):
             self._coreference_resolution = coreference_resolution
+        if self._enable_relation_extraction_validator(enable_relation_extraction):
+            self._enable_relation_extraction = enable_relation_extraction
 
     @property
     def coreference_resolution(self):
@@ -998,6 +1002,26 @@ class RelationDetection(BaseRequestObject):
             )
         return True
 
+    @property
+    def enable_relation_extraction(self):
+        return self._enable_relation_extraction
+
+    @enable_relation_extraction.setter
+    def enable_relation_extraction(self, var):
+        if self._enable_relation_extraction_validator(var):
+            self._enable_relation_extraction = var
+
+    def _enable_relation_extraction_validator(self, var):
+        if type(var) is not bool:
+            raise ValueError(
+                f"{var} is not valid. RelationDetection.enable_relation_extraction must be of type bool"
+            )
+        if var is True and self.coreference_resolution is None:
+            raise ValueError(
+                "Coreference resolution must be enabled before setting enable_relation_extraction to true"
+            )
+        return True
+
     @classmethod
     def fromdict(cls, values: dict):
         try:
@@ -1007,7 +1031,7 @@ class RelationDetection(BaseRequestObject):
             return cls._fromdict(initializer_dict)
         except TypeError:
             raise TypeError(
-                "RelationDetection can only accept the value 'coreference_resolution'"
+                "RelationDetection can only accept the values 'coreference_resolution' and 'enable_relation_extraction'"
             )
 
 

--- a/src/privateai_client/tests/test_integration.py
+++ b/src/privateai_client/tests/test_integration.py
@@ -631,3 +631,29 @@ def test_analyze_coref_combined():
     )
     resp = client.analyze_text(req)
     assert resp.ok
+
+
+def test_analyze_enable_relation_extraction_true():
+    client = _get_client()
+    req = rq.analyze_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        relation_detection=rq.relation_detection_obj(
+            coreference_resolution="combined", enable_relation_extraction=True
+        ),
+    )
+    resp = client.analyze_text(req)
+    assert resp.ok
+
+
+def test_analyze_enable_relation_extraction_false():
+    client = _get_client()
+    req = rq.analyze_text_obj(
+        text=["Hey there!"],
+        entity_detection=rq.entity_detection_obj(),
+        relation_detection=rq.relation_detection_obj(
+            coreference_resolution="combined", enable_relation_extraction=False
+        ),
+    )
+    resp = client.analyze_text(req)
+    assert resp.ok

--- a/src/privateai_client/tests/test_request_objects.py
+++ b/src/privateai_client/tests/test_request_objects.py
@@ -974,11 +974,15 @@ def test_timestamp_to_dict():
 def test_relation_detection_default_initializer():
     relation_detection = RelationDetection()
     assert relation_detection.coreference_resolution is None
+    assert relation_detection.enable_relation_extraction is False
 
 
 def test_relation_detection_initializer():
-    relation_detection = RelationDetection(coreference_resolution="model_prediction")
+    relation_detection = RelationDetection(
+        coreference_resolution="model_prediction", enable_relation_extraction=True
+    )
     assert relation_detection.coreference_resolution == "model_prediction"
+    assert relation_detection.enable_relation_extraction is True
 
 
 def test_relation_detection_initialize_fromdict():
@@ -986,13 +990,18 @@ def test_relation_detection_initialize_fromdict():
         {"coreference_resolution": "combined"}
     )
     assert relation_detection.coreference_resolution == "combined"
+    assert relation_detection.enable_relation_extraction is False
 
 
 def test_relation_detection_invalid_initialize_fromdict():
-    error_msg = "RelationDetection can only accept the value 'coreference_resolution'"
+    error_msg = "RelationDetection can only accept the values 'coreference_resolution' and 'enable_relation_extraction'"
     with pytest.raises(TypeError) as excinfo:
         RelationDetection.fromdict(
-            {"coreference_resolution": "combined", "junk": "value"}
+            {
+                "coreference_resolution": "combined",
+                "enable_relation_extraction": True,
+                "junk": "value",
+            }
         )
     assert error_msg in str(excinfo.value)
 
@@ -1000,7 +1009,9 @@ def test_relation_detection_invalid_initialize_fromdict():
 def test_relation_detection_setters():
     relation_detection = RelationDetection()
     relation_detection.coreference_resolution = "combined"
+    relation_detection.enable_relation_extraction = True
     assert relation_detection.coreference_resolution == "combined"
+    assert relation_detection.enable_relation_extraction is True
 
 
 def test_relation_detection_coreference_resolution_validator():
@@ -1011,11 +1022,28 @@ def test_relation_detection_coreference_resolution_validator():
     assert error_msg in str(excinfo.value)
 
 
+def test_relation_detection_enable_relation_extraction_validator():
+    error_msg = "junk is not valid. RelationDetection.enable_relation_extraction must be of type bool"
+    relation_detection = RelationDetection()
+    with pytest.raises(ValueError) as excinfo:
+        relation_detection.enable_relation_extraction = "junk"
+    assert error_msg in str(excinfo.value)
+
+
+def test_relation_detection_enable_relation_extraction_validator_when_coref_disabled():
+    error_msg = "Coreference resolution must be enabled before setting enable_relation_extraction to true"
+    relation_detection = RelationDetection()
+    with pytest.raises(ValueError) as excinfo:
+        relation_detection.enable_relation_extraction = True
+    assert error_msg in str(excinfo.value)
+
+
 def test_relation_detection_to_dict():
     relation_detection = RelationDetection(
-        coreference_resolution="model_prediction"
+        coreference_resolution="model_prediction", enable_relation_extraction=False
     ).to_dict()
     assert relation_detection["coreference_resolution"] == "model_prediction"
+    assert relation_detection["enable_relation_extraction"] is False
 
 
 # Process Text Request Tests
@@ -1309,7 +1337,9 @@ def test_analyze_text_request_initializer():
         filter=[filter],
         return_entity=False,
     )
-    relation_detection = RelationDetection(coreference_resolution="model_prediction")
+    relation_detection = RelationDetection(
+        coreference_resolution="model_prediction", enable_relation_extraction=True
+    )
 
     analyze_text_request = AnalyzeTextRequest(
         text=text,
@@ -1335,6 +1365,7 @@ def test_analyze_text_request_initializer():
         analyze_text_request.relation_detection.coreference_resolution
         == relation_detection.coreference_resolution
     )
+    assert analyze_text_request.relation_detection.enable_relation_extraction is True
 
 
 def test_analyze_text_request_initialize_fromdict():
@@ -1348,7 +1379,10 @@ def test_analyze_text_request_initialize_fromdict():
             "filter": [{"type": "BLOCK", "pattern": "Roger", "entity_type": "TEST"}],
             "return_entity": False,
         },
-        "relation_detection": {"coreference_resolution": "combined"},
+        "relation_detection": {
+            "coreference_resolution": "combined",
+            "enable_relation_extraction": True,
+        },
     }
     analyze_text_request = AnalyzeTextRequest.fromdict(request_obj)
     assert analyze_text_request.text == request_obj["text"]
@@ -1377,6 +1411,10 @@ def test_analyze_text_request_initialize_fromdict():
     assert (
         analyze_text_request.relation_detection.coreference_resolution
         == request_obj["relation_detection"]["coreference_resolution"]
+    )
+    assert (
+        analyze_text_request.relation_detection.enable_relation_extraction
+        == request_obj["relation_detection"]["enable_relation_extraction"]
     )
 
 
@@ -1443,6 +1481,10 @@ def test_analyze_text_request_to_dict():
     assert (
         analyze_text_request["relation_detection"]["coreference_resolution"]
         == "heuristics"
+    )
+    assert (
+        analyze_text_request["relation_detection"]["enable_relation_extraction"]
+        is False
     )
 
 


### PR DESCRIPTION
### What's Changed?
This PR introduces a new field, `enable_relation_extraction`, within the `relation_detection` object in **analyze/text**, scheduled for release in 4.2.
### PR Checklist

- [x] Updated unit tests
- [x] Ran unit tests